### PR TITLE
rust cleanup and fixes

### DIFF
--- a/deps/rust_store/src/lib.rs
+++ b/deps/rust_store/src/lib.rs
@@ -230,11 +230,11 @@ pub extern "C" fn start(config: GlobalConfigOptions) -> CResult {
                                 tokio::spawn(async move {
                                     let mut received_bytes = 0;
                                     let mut failed = false;
-                                    for chunk in chunks {
-                                        let chunk = match chunk {
+                                    for result in chunks {
+                                        let chunk = match result {
                                             Ok(c) => c,
                                             Err(_e) => {
-                                                unreachable!("checked for errors before");
+                                                unreachable!("checked `chunks` for errors before calling `spawn`");
                                             }
                                         };
                                         let len = chunk.len();

--- a/deps/rust_store/src/lib.rs
+++ b/deps/rust_store/src/lib.rs
@@ -222,7 +222,7 @@ pub extern "C" fn start(config: GlobalConfigOptions) -> CResult {
                             Ok(result) => {
                                 let chunks = result.into_stream().collect::<Vec<_>>().await;
                                 if let Some(Err(e)) = chunks.iter().find(|result| result.is_err()) {
-                                        tracing::warn!("{}", e);
+                                        tracing::warn!("Error while fetching a chunk: {}", e);
                                         response.from_error(e);
                                         notifier.notify();
                                         return;

--- a/deps/rust_store/src/lib.rs
+++ b/deps/rust_store/src/lib.rs
@@ -193,12 +193,9 @@ async fn connect(credentials: &AzureCredentials) -> anyhow::Result<Arc<dyn Objec
 
 #[no_mangle]
 pub extern "C" fn start(config: GlobalConfigOptions) -> CResult {
-    match CONFIG.set(config) {
-        Ok(_) => {},
-        Err(_) => {
-            tracing::warn!("Tried to start() runtime multiple times!");
-            return CResult::Error;
-        }
+    if let Err(_) = CONFIG.set(config) {
+        tracing::warn!("Tried to start() runtime multiple times!");
+        return CResult::Error;
     }
     tracing_subscriber::fmt::init();
 

--- a/src/ObjectStore.jl
+++ b/src/ObjectStore.jl
@@ -31,14 +31,6 @@ struct RustStoreConfig
     retry_timeout_sec::Culonglong
 end
 
-# This function will be called if Rust panics. It should only happen in the
-# case of a program bug (not, e.g., a network failure)
-function panic_handler(_::Int)::Int
-    error("Rust panic")
-    return 0
-end
-const panic_handler_c = @cfunction(panic_handler, Int, (Int,))
-
 const RUST_STORE_STARTED = Ref(false)
 const _INIT_LOCK::ReentrantLock = ReentrantLock()
 function init_rust_store(config::RustStoreConfig = RustStoreConfig(15, 150))
@@ -46,7 +38,10 @@ function init_rust_store(config::RustStoreConfig = RustStoreConfig(15, 150))
         if RUST_STORE_STARTED[]
             return
         end
-        @ccall rust_lib.start(panic_handler_c::Ptr{Cvoid}, config::RustStoreConfig)::Cint
+        res = @ccall rust_lib.start(config::RustStoreConfig)::Cint
+        if res != 0
+            error("Failed to init_rust_store")
+        end
         RUST_STORE_STARTED[] = true
     end
 end

--- a/test/azure_blobs_exception_tests.jl
+++ b/test/azure_blobs_exception_tests.jl
@@ -2,6 +2,7 @@
     using CloudBase.CloudTest: Azurite
     import CloudBase
     using ObjectStore: blob_get!, blob_put, AzureCredentials
+    import ObjectStore
 
     # For interactive testing, use Azurite.run() instead of Azurite.with()
     # conf, p = Azurite.run(; debug=true, public=false); atexit(() -> kill(p))
@@ -141,6 +142,18 @@
         catch e
             @test e isa ErrorException
             @test occursin("Connection refused", e.msg)
+        end
+    end
+
+    @testset "panic handle" begin
+        config = RustStoreConfig(5, 5)
+        try
+            @ccall ObjectStore.rust_lib.start(ObjectStore.panic_handler_c::Ptr{Cvoid},
+                        config::RustStoreConfig)::Cint
+            @test false # Should have thrown an error
+        catch e
+            @test e isa ErrorException
+            @test occursin("Rust panic", e.msg)
         end
     end
 end # @testitem

--- a/test/azure_blobs_exception_tests.jl
+++ b/test/azure_blobs_exception_tests.jl
@@ -145,15 +145,9 @@
         end
     end
 
-    @testset "panic handle" begin
+    @testset "multiple start" begin
         config = RustStoreConfig(5, 5)
-        try
-            @ccall ObjectStore.rust_lib.start(ObjectStore.panic_handler_c::Ptr{Cvoid},
-                        config::RustStoreConfig)::Cint
-            @test false # Should have thrown an error
-        catch e
-            @test e isa ErrorException
-            @test occursin("Rust panic", e.msg)
-        end
+        res = @ccall ObjectStore.rust_lib.start(config::RustStoreConfig)::Cint
+        @test res == 1 # Rust CResult::Error
     end
 end # @testitem


### PR DESCRIPTION
- Return error instead of panic for multiple calls to `start`
- Return error instead of panic for calling `perform_get/put` before `start`
- Remove unneeded throughput calculation task
- Remove connection test and manual retries
- Rust comments and cleanup