### PR TITLE
Get `Pkg.build()` working on Mac

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -41,7 +41,7 @@ run(`which cargo`)
 assert_compatible_version(`cargo -V`, "1.55.0")
 rust_source = joinpath(@__DIR__, "rust_store")
 # Elide rust warnings - they aren't helpful in this context
-ENV["RUSTFLAGS"]="-Awarnings"
+ENV["RUSTFLAGS"]="-Awarnings -Clink-arg=-undefined -Clink-arg=dynamic_lookup"
 # build release
 cd(rust_source)
 if Sys.islinux() || Sys.isapple()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -41,7 +41,11 @@ run(`which cargo`)
 assert_compatible_version(`cargo -V`, "1.55.0")
 rust_source = joinpath(@__DIR__, "rust_store")
 # Elide rust warnings - they aren't helpful in this context
-ENV["RUSTFLAGS"]="-Awarnings -Clink-arg=-undefined -Clink-arg=dynamic_lookup"
+if Sys.isapple()
+    ENV["RUSTFLAGS"]="-Awarnings -Clink-arg=-undefined -Clink-arg=dynamic_lookup"
+else
+    ENV["RUSTFLAGS"]="-Awarnings"
+end
 # build release
 cd(rust_source)
 if Sys.islinux() || Sys.isapple()


### PR DESCRIPTION
idk why this scrip doesn't find the `.cargo/config.toml` file, but there's no harm in setting these flags directly in the script as needed