### PR TITLE
Add BinaryBuilder build_tarballs.jl script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/Manifest.toml
+Manifest.toml
 *.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 RelationalAI, and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Project.toml
+++ b/Project.toml
@@ -2,9 +2,6 @@ name = "ObjectStore"
 uuid = "1b5eed3d-1f46-4baa-87f3-a4a892b23610"
 version = "0.1.0"
 
-[deps]
-object_store_ffi_jll = "0e112785-0821-598c-8835-9f07837e8d7b"
-
 [compat]
 CloudBase = "1"
 HTTP = "1"
@@ -12,7 +9,6 @@ ReTestItems = "1"
 Sockets = "1"
 Test = "1"
 julia = "1.8"
-object_store_ffi_jll = "0.1"
 
 [extras]
 CloudBase = "85eb1798-d7c4-4918-bb13-c944d38e27ed"

--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,9 @@ name = "ObjectStore"
 uuid = "1b5eed3d-1f46-4baa-87f3-a4a892b23610"
 version = "0.1.0"
 
+[deps]
+object_store_ffi_jll = "0e112785-0821-598c-8835-9f07837e8d7b"
+
 [compat]
 CloudBase = "1"
 HTTP = "1"
@@ -9,6 +12,7 @@ ReTestItems = "1"
 Sockets = "1"
 Test = "1"
 julia = "1.8"
+object_store_ffi_jll = "0.1"
 
 [extras]
 CloudBase = "85eb1798-d7c4-4918-bb13-c944d38e27ed"

--- a/deps/README.md
+++ b/deps/README.md
@@ -1,0 +1,5 @@
+# deps/
+
+- `deps/object_store_ffi` -- the Rust library that defines a C API for `object_store`
+- `deps/binary_builder` -- the script that uses `BinaryBuilder.jl` to build the `object_store_ffi` binaries and generate the `deps/object_store_ffi_jll.jl` package
+- `deps/object_store_ffi_jll.jl` -- the auto-generated Julia package that installs `object_store_ffi` binaries, and on which `ObjectStore.jl` depends.

--- a/deps/README.md
+++ b/deps/README.md
@@ -1,5 +1,4 @@
 # deps/
 
-- `deps/object_store_ffi` -- the Rust library that defines a C API for `object_store`
-- `deps/binary_builder` -- the script that uses `BinaryBuilder.jl` to build the `object_store_ffi` binaries and generate the `deps/object_store_ffi_jll.jl` package
-- `deps/object_store_ffi_jll.jl` -- the auto-generated Julia package that installs `object_store_ffi` binaries, and on which `ObjectStore.jl` depends.
+- `deps/object_store_ffi` -- the Rust library that defines a C API for [`object_store`](https://github.com/apache/arrow-rs/tree/master/object_store).
+- `deps/binary_builder` -- the script that uses [`BinaryBuilder.jl`](https://github.com/JuliaPackaging/BinaryBuilder.jl) to build the `object_store_ffi` binaries and generate the `object_store_ffi_jll.jl` package.

--- a/deps/binary_builder/.gitignore
+++ b/deps/binary_builder/.gitignore
@@ -1,0 +1,2 @@
+/products/
+/build/

--- a/deps/binary_builder/Project.toml
+++ b/deps/binary_builder/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
+
+[compat]
+BinaryBuilder = "0.5"

--- a/deps/binary_builder/build_tarballs.jl
+++ b/deps/binary_builder/build_tarballs.jl
@@ -1,0 +1,41 @@
+using BinaryBuilder
+
+cd(@__DIR__)
+
+name = "object_store_ffi"
+version = v"0.1.0"
+
+sources = [
+    DirectorySource(joinpath("..", "object_store_ffi")),
+]
+
+# Bash recipe for building across all platforms
+script = raw"""
+cd ${WORKSPACE}/srcdir/
+cargo rustc --release --lib --crate-type=cdylib
+install -Dvm 755 "target/${rust_target}/release/libobject_store_ffi.${dlext}" "${libdir}/libobject_store_ffi.${dlext}"
+"""
+
+# We could potentially support more platforms, if required.
+# Except perhaps i686 Windows and Musl systems.
+platforms = [
+    Platform("aarch64", "macos"),
+    Platform("x86_64",  "linux"),
+    # Platform("x86_64",  "macos"),
+    # Platform("aarch64", "linux"),
+]
+
+# The products that we will ensure are always built
+products = [
+    LibraryProduct("libobject_store_ffi", :libobject_store_ffi),
+]
+
+# Dependencies that must be installed before this package can be built
+dependencies = [
+]
+
+# Build the tarballs
+build_tarballs(
+    ARGS, name, version, sources, script, platforms, products, dependencies;
+    compilers=[:c, :rust], julia_compat="1.6"
+)

--- a/deps/object_store_ffi/Cargo.toml
+++ b/deps/object_store_ffi/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
-[profile.release]
-debug = true
+# # https://doc.rust-lang.org/cargo/reference/profiles.html
+# [profile.release]
+# debug = "limited"
 
 [dependencies]
 tokio = { version = "1.32.0", features = ["rt-multi-thread", "macros", "signal", "time"] }
@@ -16,7 +17,6 @@ bytes = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 futures-util = "0.3"
-# object_store = { git = "https://github.com/andrebsguedes/arrow-rs.git", branch = "dns", features = ["azure"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "trust-dns"] }
 object_store = { version = "0.8", features = ["azure"] }
 thiserror = "1"

--- a/deps/object_store_ffi/LICENSE
+++ b/deps/object_store_ffi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 RelationalAI, and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
After trying out lots of different options for how to build/host/distribute binaries, i'm proposing we just use BinaryBuilder.jl and do so in the way it's intended to be used... except hosting the build_tarballs.jl script here (instead of in Yggdrasil) and the resulting package in an RAI GitHub org (instead of in JuliaBinaryWrappers org)

The means we can use BinaryBuilder.jl to build binaries, create a JLL Julia package for distributing them, and handle uploading both the package and binaries to a GitHub repo. And that we are free to make releases without going via Yggrasil and needing a PR approval their. The downside is that Yggdrasil CI won't build the binaries for us (for now we can just build locally and later figure out a nicer CI-base setup if necessary). And the JLL package is outside this repo (because BinaryBuilder isn't really set up for the JLL and binaries to be anywhere other than in their own repo).