### PR TITLE
Rename package ObjectStore -> RustyObjectStore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "ObjectStore"
+name = "RustyObjectStore"
 uuid = "1b5eed3d-1f46-4baa-87f3-a4a892b23610"
 version = "0.1.0"
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# ObjectStore.jl2
+# RustyObjectStore.jl

--- a/src/RustyObjectStore.jl
+++ b/src/RustyObjectStore.jl
@@ -1,4 +1,4 @@
-module ObjectStore
+module RustyObjectStore
 
 export init_object_store, blob_get!, blob_put, AzureCredentials, ObjectStoreConfig
 

--- a/test/azure_blobs_exception_tests.jl
+++ b/test/azure_blobs_exception_tests.jl
@@ -1,8 +1,7 @@
 @testitem "Basic BlobStorage exceptions" setup=[InitializeObjectStore] begin
     using CloudBase.CloudTest: Azurite
     import CloudBase
-    using ObjectStore: blob_get!, blob_put, AzureCredentials
-    import ObjectStore
+    using RustyObjectStore: RustyObjectStore, blob_get!, blob_put, AzureCredentials
 
     # For interactive testing, use Azurite.run() instead of Azurite.with()
     # conf, p = Azurite.run(; debug=true, public=false); atexit(() -> kill(p))
@@ -147,7 +146,7 @@
 
     @testset "multiple start" begin
         config = ObjectStoreConfig(5, 5)
-        res = @ccall ObjectStore.rust_lib.start(config::ObjectStoreConfig)::Cint
+        res = @ccall RustyObjectStore.rust_lib.start(config::ObjectStoreConfig)::Cint
         @test res == 1 # Rust CResult::Error
     end
 end # @testitem
@@ -164,7 +163,7 @@ end # @testitem
 @testitem "BlobStorage retries" setup=[InitializeObjectStore] begin
     using CloudBase.CloudTest: Azurite
     import CloudBase
-    using ObjectStore: blob_get!, blob_put, AzureCredentials
+    using RustyObjectStore: blob_get!, blob_put, AzureCredentials
     import HTTP
     import Sockets
 

--- a/test/azure_blobs_tests.jl
+++ b/test/azure_blobs_tests.jl
@@ -1,6 +1,6 @@
 @testitem "Basic BlobStorage usage" setup=[InitializeObjectStore] begin
 using CloudBase.CloudTest: Azurite
-using ObjectStore: blob_get!, blob_put, AzureCredentials
+using RustyObjectStore: blob_get!, blob_put, AzureCredentials
 
 # For interactive testing, use Azurite.run() instead of Azurite.with()
 # conf, p = Azurite.run(; debug=true, public=false); atexit(() -> kill(p))
@@ -105,7 +105,7 @@ end # @testitem
 # TODO: implement a way for GET to be called without credentials
 @test_skip begin
 using CloudBase.CloudTest: Azurite
-using ObjectStore: blob_get!, blob_put, AzureCredentials
+using RustyObjectStore: blob_get!, blob_put, AzureCredentials
 
 # For interactive testing, use Azurite.run() instead of Azurite.with()
 # conf, p = Azurite.run(; debug=true, public=true); atexit(() -> kill(p))

--- a/test/common_testsetup.jl
+++ b/test/common_testsetup.jl
@@ -1,5 +1,5 @@
 @testsetup module InitializeObjectStore
-    using ObjectStore
+    using RustyObjectStore
     # Since we currently only support centralized configs, we need to have one that is compatible
     # with all the tests (some of the tests would take too long if we use default values).
     max_retries = 2

--- a/test/release_test.jl
+++ b/test/release_test.jl
@@ -3,5 +3,5 @@
 # for development reasons, but it should never be set in CI.
 @testitem "Using object_store_ffi_jll" begin
     using object_store_ffi_jll
-    @test ObjectStore.rust_lib == object_store_ffi_jll.libobject_store_ffi
+    @test RustyObjectStore.rust_lib == object_store_ffi_jll.libobject_store_ffi
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ReTestItems
-using ObjectStore
+using RustyObjectStore
 
 withenv("RUST_BACKTRACE"=>1) do
-    runtests(ObjectStore, testitem_timeout=180, nworkers=1)
+    runtests(RustyObjectStore; testitem_timeout=180, nworkers=1)
 end


### PR DESCRIPTION
To avoid name clash with already registered Julia packages.

https://github.com/JuliaRegistries/General/pull/98486#issuecomment-1881734602

> The following guidelines were not met:
> - Package name similar to 1 existing package.
>   - Similar to ObjectStores. Damerau-Levenshtein distance 1 is at or below cutoff of 2. Damerau-Levenshtein distance 1 between lowercased names is at or below cutoff of 1. Normalized visual distance 2.19 is at or below cutoff of 2.50.
>
> Note that the guidelines are only required for the pull request to be merged automatically. However, it is strongly recommended to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.

Consensus on JuliaLang slack was that our package should change name... i don't mind what we call it, although i'd prefer it to have a name not too easily confused with CloudStore.jl

This is my proposal (whatever we decide, we then need to rename the repo too)